### PR TITLE
[ROG-338] Fix ISP scaling and disparity -> depth calculations

### DIFF
--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -30,6 +30,7 @@ rclcpp
 sensor_msgs
 diagnostic_updater
 diagnostic_msgs
+depthai_ros_msgs
 )
 
 set(SENSOR_DEPS

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
@@ -13,6 +13,7 @@
 #include "image_transport/camera_publisher.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/compressed_image.hpp"
+#include "depthai_ros_msgs/msg/disparity_info.hpp"
 
 namespace dai {
 class Device;
@@ -80,6 +81,18 @@ void compressedSplitPub(const std::string& /*name*/,
               std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager,
               bool lazyPub = true);
 
+void compressedDisparitySplitPub(const std::string& /*name*/,
+              const std::shared_ptr<dai::ADatatype>& data,
+              dai::ros::ImageConverter& converter,
+              rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr imgPub,
+              rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr infoPub,
+              std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager,
+              rclcpp::Publisher<depthai_ros_msgs::msg::DisparityInfo>::SharedPtr dispInfoPub,
+              bool extended_disp,
+              double baseline,
+              double focal_px,
+              bool lazyPub = true);
+
 sensor_msgs::msg::CameraInfo getCalibInfo(const rclcpp::Logger& logger,
                                           dai::ros::ImageConverter& converter,
                                           std::shared_ptr<dai::Device> device,
@@ -94,6 +107,10 @@ bool detectSubscription(const rclcpp::Publisher<sensor_msgs::msg::Image>::Shared
 
 bool detectSubscription(const rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr& pub,
                         const rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr& infoPub);
+
+bool detectSubscription(const rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr& pub,
+                        const rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr& infoPub,
+                        const rclcpp::Publisher<depthai_ros_msgs::msg::DisparityInfo>::SharedPtr& dispPub);
 }  // namespace sensor_helpers
 }  // namespace dai_nodes
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
@@ -12,6 +12,7 @@
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "sensor_msgs/msg/compressed_image.hpp"
+#include "depthai_ros_msgs/msg/disparity_info.hpp"
 
 namespace dai {
 class Pipeline;
@@ -92,6 +93,7 @@ class Stereo : public BaseNode {
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr stereoPub, leftRectPub, rightRectPub;
     rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr compressedStereoPub, compressedLeftRectPub, compressedRightRectPub;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr stereoInfoPub, leftRectInfoPub, rightRectInfoPub;
+    rclcpp::Publisher<depthai_ros_msgs::msg::DisparityInfo>::SharedPtr dispInfoPub;
     std::shared_ptr<camera_info_manager::CameraInfoManager> stereoIM, leftRectIM, rightRectIM;
     std::shared_ptr<dai::node::StereoDepth> stereoCamNode;
     std::shared_ptr<dai::node::VideoEncoder> stereoEnc, leftRectEnc, rightRectEnc;

--- a/depthai_ros_msgs/CMakeLists.txt
+++ b/depthai_ros_msgs/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/AutoFocusCtrl.msg"
+  "msg/DisparityInfo.msg"
   "msg/HandLandmark.msg"
   "msg/HandLandmarkArray.msg"
   "msg/ImuWithMagneticField.msg"

--- a/depthai_ros_msgs/msg/DisparityInfo.msg
+++ b/depthai_ros_msgs/msg/DisparityInfo.msg
@@ -1,0 +1,32 @@
+# Contains information required to decode disparity to depth
+#
+# When using align to RGB, the original baseline and focal length is lost,
+# so this message provides the necessary info
+#
+# Practically, this is a workaround to poor python->ros interop.  If other nodes
+# are written in C++ and we can use intraprocess communication, then we can just
+# pass decompressed messages from here instead.
+#
+# Structure borrowed from: stereo_msgs/DisparityImage
+std_msgs/Header header
+
+# Stereo geometry. For disparity d, the depth from the camera is Z = fT/d.
+float32 f # Focal length, pixels
+float32 t # Baseline, world units
+
+# Subwindow of (potentially) valid disparity values.
+sensor_msgs/RegionOfInterest valid_window
+
+# The range of disparities searched.
+# In the disparity image, any disparity less than min_disparity is invalid.
+# The disparity search range defines the horopter, or 3D volume that the
+# stereo algorithm can "see". Points with Z outside of:
+#     Z_min = fT / max_disparity
+#     Z_max = fT / min_disparity
+# could not be found.
+float32 min_disparity
+float32 max_disparity
+
+# Smallest allowed disparity increment. The smallest achievable depth range
+# resolution is delta_Z = (Z^2/fT)*delta_d.
+float32 delta_d


### PR DESCRIPTION
### Description

Update driver and stem detection to fix incorrect scaling of camera parameters and disparity/depth calculations.

### Reason

Avoiding workarounds in the code in preparation for using depth in the inference node.

### Method / Design

- New DisparityInfo topic appears when using low_bandwidth_passthrough mode
  - DisparityInfo topic is modeled after the more common DisparityImage topic that we cannot use, since we use compressed images.
  - I also decided against creating a custom CompressedDisparityImage topic, as many parsers and display tools wouldn't be able to understand it properly.
- The DisparityInfo focal length is only affected by changes in the mono left/right resoltuions, and no longer affected by scaling the image to match the rgb

### Testing

- Verified DisparityInfo only changes when mono camera resolution is changed
- Verified mono, disparity, and rgb topics continue to be published as usual

### Additional Information

**IMPORTANT** The scaling will still break if `i_width` and `i_height` are used, however using the ISP scaling will work correctly.

Related PRs:
https://github.com/SenteraLLC/py-edge-rogues-ros/pull/20
https://github.com/SenteraLLC/depthai-ros/pull/1
https://github.com/SenteraLLC/cpp_edge_rogues_plant_detection/pull/5